### PR TITLE
Check if element is still attached to DOM before calling renderTile

### DIFF
--- a/lib/knockout.list.js
+++ b/lib/knockout.list.js
@@ -221,8 +221,9 @@
                 var dividerCacheKeys = Object.keys(dividerCache);
                 if (tileCacheKeys.length === 0) {
                     dataSource.get(0, function (item) {
-                        if (dataSource.length() === 0) {
-                            return; // The data source has been emptied
+                        if (dataSource.length() === 0 ||
+                            !ko.utils.domNodeIsAttachedToDocument(element)) {
+                            return; // The data source has been emptied or the element got disconnected from the DOM
                         }
                         var $tile = renderTile(item, 0);
                         tileHeight = $tile.outerHeight();
@@ -286,7 +287,8 @@
 
             function updateIndex(index) {
                 dataSource.get(index, function (item, i) {
-                    if (i < dataSource.length() && indexRange.start <= i && i <= indexRange.end) {
+                    if (i < dataSource.length() && indexRange.start <= i && i <= indexRange.end &&
+                        ko.utils.domNodeIsAttachedToDocument(element)) {
                         renderTile(item, i);
                     }
                 });


### PR DESCRIPTION
This fixes an issue where the element is removed from the DOM while knockout.list is still rendering its content.
