### PR TITLE
Call blur on focused element if that element is removed from the dom

### DIFF
--- a/lib/knockout.list.js
+++ b/lib/knockout.list.js
@@ -401,13 +401,15 @@
                 }).forEach(removeIndexFromTileCache);
             }
 
+            var renderTileIfDomNodeAttachedToDocument = function (item, i) {
+                if (i < dataSource.length() && indexRange.start <= i && i <= indexRange.end &&
+                    ko.utils.domNodeIsAttachedToDocument(element)) {
+                    renderTile(item, i);
+                }
+            };
+
             function updateIndex(index) {
-                dataSource.get(index, function (item, i) {
-                    if (i < dataSource.length() && indexRange.start <= i && i <= indexRange.end &&
-                        ko.utils.domNodeIsAttachedToDocument(element)) {
-                        renderTile(item, i);
-                    }
-                });
+                dataSource.get(index, renderTileIfDomNodeAttachedToDocument);
             }
 
             function renderViewPort() {


### PR DESCRIPTION
First of all, this is just a proposal and I have some other ideas for solving the problem I'm having.

The problem is that I'd like to know when an element that currently has focus is removed from the DOM by knockout.list, so that I can do cleanup logic, and maybe set the focus to another element.

This pull request adds logic to automatically blur an element if it has dom focus, let's call the pull request proposal 1. It currently only catches direct children of the rendered tiles though. 

If a deeper descendant has focus, proposal 2 would be needed:
1. Also switch the binding context of the actual tiles, with ko.applyBindings
2. Compare ko.dataFor(document.activeElement) === ko.dataFor(tileCache[index][0])
3. Call document.activeElement.blur() if it is

For step 2, ko.dataFor(document.activeElement) of course only has to be calculated once, but either ko.dataFor(tileCache[index][0]) or dataSource.get(index) would have to be called for each element to remove. 
Not sure if that would be acceptable - but maybe an extra cache could be added which holds the data for each element currently present in the tileCache.

@sunesimonsen do you perhaps have time to comment on these two proposals?
