### PR TITLE
Optimise amount of elements rendered in scrollable mode

### DIFF
--- a/examples/scrollable.html
+++ b/examples/scrollable.html
@@ -27,6 +27,9 @@
           <div tabindex="-1" data-bind="list: {data: dataSource, visibleIndex: visibleIndex, scrollable: '.scrollable'}">
             <span data-bind="text: $data"></span>
           </div>
+          <div style="height: 1000px; border: 1px solid gray;">
+            <p>This area is part of a scrollable parent.<br>knockout.list takes the offset into account if you can read this.</p>
+          </div>
         </div>
       </div>
       <script type="text/javascript" src="../vendor/es5-shim.js"></script>

--- a/lib/knockout.list.js
+++ b/lib/knockout.list.js
@@ -167,9 +167,17 @@
                 return dividersBeforeIndex(index) * dividerHeight + calculateVerticalTileIndex(viewIndex) * tileHeight;
             }
 
+            function calculateScrollElementRelativeVerticalTilePosition(index) {
+                return calculateVerticalTilePosition(index) + elementOffsetTop;
+            }
+
             function calculateHorizontalTilePosition(index) {
                 var viewIndex = calculateViewIndex(index);
                 return tileWidth * calculateHorizontalTileIndex(viewIndex);
+            }
+
+            function calculateScrollElementRelativeHorizontalTilePosition(index) {
+                return calculateVerticalTilePosition(index) + elementOffsetLeft;
             }
 
             function getDividersBeforeIndex(index) {

--- a/lib/knockout.list.js
+++ b/lib/knockout.list.js
@@ -386,17 +386,12 @@
 
             function calculateStartIndex() {
                 var viewport = {
-                    top: $scrollElement.scrollTop() - elementOffsetTop
+                    top: $scrollElement.scrollTop()
                 };
 
-                if (viewport.top < 0) {
-                    viewport.top = 0;
-                }
+                var startIndex = Math.floor((viewport.top - elementOffsetTop) / tileHeight) * tilesSideBySide;
 
-                var startIndex = viewport.top === 0 ? 0 :
-                    Math.floor(viewport.top / tileHeight) * tilesSideBySide;
-
-                while (viewport.top < calculateVerticalTilePosition(startIndex)) {
+                while (viewport.top < calculateScrollElementRelativeVerticalTilePosition(startIndex)) {
                     startIndex -= 1;
                 }
 

--- a/lib/knockout.list.js
+++ b/lib/knockout.list.js
@@ -403,7 +403,6 @@
                     startIndex = calculateStartIndex();
                 }
 
-                // TODO: Would be nice to also check viewport.bottom and do same to endIndex as done to startIndex
                 var lastIndex = dataSource.length() - 1,
                     skipViewportIndexesBeforeStart = 0,
                     skipViewportIndexesAfterEnd = 0;

--- a/lib/knockout.list.js
+++ b/lib/knockout.list.js
@@ -404,14 +404,26 @@
                 }
 
                 // TODO: Would be nice to also check viewport.bottom and do same to endIndex as done to startIndex
+                var lastIndex = dataSource.length() - 1,
+                    skipViewportIndexesBeforeStart = 0,
+                    skipViewportIndexesAfterEnd = 0;
+
+                if (startIndex < 0) {
+                    skipViewportIndexesAfterEnd = -startIndex;
+                    startIndex = 0;
+                } else if (startIndex > lastIndex) {
+                    skipViewportIndexesBeforeStart = lastIndex - startIndex
+                    startIndex = lastIndex;
+                }
+
                 var endIndex = viewportIndexes - 1  + startIndex;
 
                 if (neverEvictTiles) {
                     indexRange.start = 0;
-                    indexRange.end = dataSource.length() - 1;
+                    indexRange.end = lastIndex;
                 } else {
-                    indexRange.start = Math.max(0, startIndex - viewportIndexes);
-                    indexRange.end = Math.min(dataSource.length() - 1,  endIndex + viewportIndexes);
+                    indexRange.start = Math.max(0, startIndex - (viewportIndexes + skipViewportIndexesBeforeStart));
+                    indexRange.end = Math.min(lastIndex,  endIndex + (viewportIndexes - skipViewportIndexesAfterEnd));
                 }
             }
             function removeTileFromCacheOutsideOfIndexRange() {

--- a/test/knockout.list.spec.js
+++ b/test/knockout.list.spec.js
@@ -130,7 +130,7 @@ describe('knockout.list with height ' + viewportHeight + 'px and items of height
                         };
                         ko.applyBindings(model, element);
                         clock.tick(110);
-                        scrollElement.scrollTop = element.scrollHeight;
+                        scrollToBottom(scrollElement);
                     });
 
                     it('still has ' + numberOfItems + ' tiles', function () {
@@ -938,7 +938,7 @@ describe('knockout.list grid with height ' + viewportHeight + 'px, width ' + vie
 
             describe('and the viewport is scrolled to the bottom', function () {
                 beforeEach(function () {
-                    scrollElement.scrollTop = element.scrollHeight;
+                    scrollToBottom(scrollElement);
                 });
 
                 it('still has ' + numberOfItems + ' tiles', function () {

--- a/test/knockout.list.spec.js
+++ b/test/knockout.list.spec.js
@@ -494,7 +494,7 @@ describe('knockout.list with height ' + viewportHeight + 'px and items of height
                     });
 
                     it('has scroll height equal to container', function () {
-                        expect(scrollElement, 'to have scroll height', dividerHeight * 3 + offsetElementHeight);
+                        expect(scrollElement, 'to have scroll height', dividerHeight * 3 + 2 * offsetElementHeight);
                     });
 
                     it('has content height equals to the height of all dividers', function () {
@@ -525,7 +525,7 @@ describe('knockout.list with height ' + viewportHeight + 'px and items of height
                 });
 
                 it('has scroll height equals to the height of all items', function () {
-                    expect(scrollElement, 'to have scroll height', numberOfItems * itemHeight + offsetElementHeight);
+                    expect(scrollElement, 'to have scroll height', numberOfItems * itemHeight + 2 * offsetElementHeight);
                 });
 
                 it('has content height equals to the height of all items', function () {
@@ -560,7 +560,7 @@ describe('knockout.list with height ' + viewportHeight + 'px and items of height
                         });
 
                         it('has scroll height equals to the height of all items and dividers', function () {
-                            expect(scrollElement, 'to have scroll height', dividerHeight * 3 + numberOfItems * itemHeight + offsetElementHeight);
+                            expect(scrollElement, 'to have scroll height', dividerHeight * 3 + numberOfItems * itemHeight + 2 * offsetElementHeight);
                         });
 
                         it('has content height equals to the height of all items and dividers', function () {
@@ -600,7 +600,7 @@ describe('knockout.list with height ' + viewportHeight + 'px and items of height
                 });
 
                 it('has scroll height equals to the height of all items', function () {
-                    expect(scrollElement, 'to have scroll height', numberOfItems * itemHeight + offsetElementHeight);
+                    expect(scrollElement, 'to have scroll height', numberOfItems * itemHeight + 2 * offsetElementHeight);
                 });
 
                 it('has content height equals to the height of all items', function () {
@@ -657,7 +657,7 @@ describe('knockout.list with height ' + viewportHeight + 'px and items of height
                         });
 
                         it('has scroll height equals to the height of all items and dividers', function () {
-                            expect(scrollElement, 'to have scroll height', dividerHeight * 3 + numberOfItems * itemHeight + offsetElementHeight);
+                            expect(scrollElement, 'to have scroll height', dividerHeight * 3 + numberOfItems * itemHeight + 2 * offsetElementHeight);
                         });
 
                         it('has content height equals to the height of all items and dividers', function () {
@@ -676,8 +676,8 @@ describe('knockout.list with height ' + viewportHeight + 'px and items of height
                         clock.tick(110);
                     });
 
-                    it('has tiles item94 to item99', function () {
-                        expect(element, 'to only have tiles', tileRange(94, 99));
+                    it('has tiles item95 to item99', function () {
+                        expect(element, 'to only have tiles', tileRange(95, 99));
                     });
 
                     it('has no overlapping tiles', function () {
@@ -695,7 +695,7 @@ describe('knockout.list with height ' + viewportHeight + 'px and items of height
                         });
 
                         it('has scroll height equals to the height of all items and dividers', function () {
-                            expect(scrollElement, 'to have scroll height', dividerHeight * 3 + numberOfItems * itemHeight + offsetElementHeight);
+                            expect(scrollElement, 'to have scroll height', dividerHeight * 3 + numberOfItems * itemHeight + 2 * offsetElementHeight);
                         });
 
                         it('has content height equals to the height of all items and dividers', function () {
@@ -722,7 +722,7 @@ describe('knockout.list with height ' + viewportHeight + 'px and items of height
                     });
 
                     it('has scroll height equals to the height of all items', function () {
-                        expect(scrollElement, 'to have scroll height', (numberOfItems + 1) * itemHeight + offsetElementHeight);
+                        expect(scrollElement, 'to have scroll height', (numberOfItems + 1) * itemHeight + 2 * offsetElementHeight);
                     });
 
                     it('has content height equals to the height of all items', function () {
@@ -748,7 +748,7 @@ describe('knockout.list with height ' + viewportHeight + 'px and items of height
                     });
 
                     it('has scroll height equals to the height of all items', function () {
-                        expect(scrollElement, 'to have scroll height', (numberOfItems + 1) * itemHeight + offsetElementHeight);
+                        expect(scrollElement, 'to have scroll height', (numberOfItems + 1) * itemHeight + 2 * offsetElementHeight);
                     });
 
                     it('has content height equals to the height of all items', function () {
@@ -772,7 +772,7 @@ describe('knockout.list with height ' + viewportHeight + 'px and items of height
                     });
 
                     it('has scroll height equals to the height of all items', function () {
-                        expect(scrollElement, 'to have scroll height', (numberOfItems + 1) * itemHeight + offsetElementHeight);
+                        expect(scrollElement, 'to have scroll height', (numberOfItems + 1) * itemHeight + 2 * offsetElementHeight);
                     });
 
                     it('has content height equals to the height of all items', function () {
@@ -798,7 +798,7 @@ describe('knockout.list with height ' + viewportHeight + 'px and items of height
                     });
 
                     it('has scroll height equals to the height of all items', function () {
-                        expect(scrollElement, 'to have scroll height', numberOfItems * itemHeight + offsetElementHeight);
+                        expect(scrollElement, 'to have scroll height', numberOfItems * itemHeight + 2 * offsetElementHeight);
                     });
 
                     it('has content height equals to the height of all items', function () {
@@ -823,7 +823,7 @@ describe('knockout.list with height ' + viewportHeight + 'px and items of height
                     });
 
                     it('has scroll height equals to the height of all items', function () {
-                        expect(scrollElement, 'to have scroll height', numberOfItems * itemHeight + offsetElementHeight);
+                        expect(scrollElement, 'to have scroll height', numberOfItems * itemHeight + 2 * offsetElementHeight);
                     });
 
                     it('has content height equals to the height of all items', function () {

--- a/test/knockout.list.spec.js
+++ b/test/knockout.list.spec.js
@@ -453,96 +453,428 @@ describe('knockout.list with height ' + viewportHeight + 'px and items of height
     }); // end 'scrolling through the same element as it is bound to'
 
     describe('scrolling through parent of element it is bound to', function () {
-        beforeEach(function () {
-            element = createTestElementWithScrollableParent({
-                viewportHeight: viewportHeight,
-                itemHeight: itemHeight,
-                offsetElementHeight: offsetElementHeight
+
+        describe('with offset elements of ' + offsetElementHeight + 'px tall above and below list', function () {
+            beforeEach(function () {
+                element = createTestElementWithScrollableParent({
+                    viewportHeight: viewportHeight,
+                    itemHeight: itemHeight,
+                    offsetElementHeight: offsetElementHeight
+                });
+                scrollElement = $(element).parents('.scrollable').get(0);
             });
-            scrollElement = $(element).parents('.scrollable').get(0);
-        });
 
-        describe('with an observable array as data source', function () {
-            describe('when the data source is empty', function () {
-                var model;
-                beforeEach(function () {
-                    model = { items: ko.observableArray(), dividers: ko.observable() };
-                    ko.applyBindings(model, element);
-                    clock.tick(110);
-                });
-
-                it('renders no tiles', function () {
-                    expect(element, 'to have number of tiles', 0);
-                });
-
-                it('has scroll height equal to container', function () {
-                    expect(scrollElement, 'to have scroll height', viewportHeight);
-                });
-
-                it('has content height equals to the height of all items', function () {
-                    expect(element, 'to have content height', 0);
-                });
-
-                describe('and it has 3 dividers', function () {
+            describe('with an observable array as data source', function () {
+                describe('when the data source is empty', function () {
+                    var model;
                     beforeEach(function () {
-                        model.dividers({ 20: "A", 40: 'B', 60: 'C' });
+                        model = { items: ko.observableArray(), dividers: ko.observable() };
+                        ko.applyBindings(model, element);
                         clock.tick(110);
                     });
 
-                    it('places all dividers sequential from the start of the list', function () {
-                        expect(element, 'to have number of dividers', 3);
+                    it('renders no tiles', function () {
+                        expect(element, 'to have number of tiles', 0);
                     });
 
                     it('has scroll height equal to container', function () {
-                        expect(scrollElement, 'to have scroll height', dividerHeight * 3 + 2 * offsetElementHeight);
+                        expect(scrollElement, 'to have scroll height', viewportHeight);
                     });
 
-                    it('has content height equals to the height of all dividers', function () {
-                        expect(element, 'to have content height', dividerHeight * 3);
+                    it('has content height equals to the height of all items', function () {
+                        expect(element, 'to have content height', 0);
+                    });
+
+                    describe('and it has 3 dividers', function () {
+                        beforeEach(function () {
+                            model.dividers({ 20: "A", 40: 'B', 60: 'C' });
+                            clock.tick(110);
+                        });
+
+                        it('places all dividers sequential from the start of the list', function () {
+                            expect(element, 'to have number of dividers', 3);
+                        });
+
+                        it('has scroll height equal to container', function () {
+                            expect(scrollElement, 'to have scroll height', dividerHeight * 3 + 2 * offsetElementHeight);
+                        });
+
+                        it('has content height equals to the height of all dividers', function () {
+                            expect(element, 'to have content height', dividerHeight * 3);
+                        });
+
+                        it('has no overlapping tiles', function () {
+                            expect(element, 'to have no gap or overlapping between tiles and dividers');
+                        });
+                    });
+                });
+
+                describe('when the data source is smaller then the eviction treshold of 100 items', function () {
+                    var model;
+                    var numberOfItems = 99;
+                    beforeEach(function () {
+                        model = {
+                            items: ko.observableArray(itemFactory.create(numberOfItems)),
+                            visibleIndex: ko.observable(0).extend({ notify: 'always' }),
+                            dividers: ko.observable()
+                        };
+                        ko.applyBindings(model, element);
+                        clock.tick(110);
+                    });
+
+                    it('renders ' + numberOfItems + ' tiles', function () {
+                        expect(element, 'to have number of tiles', numberOfItems);
+                    });
+
+                    it('has scroll height equals to the height of all items', function () {
+                        expect(scrollElement, 'to have scroll height', numberOfItems * itemHeight + 2 * offsetElementHeight);
+                    });
+
+                    it('has content height equals to the height of all items', function () {
+                        expect(element, 'to have content height', numberOfItems * itemHeight);
                     });
 
                     it('has no overlapping tiles', function () {
-                        expect(element, 'to have no gap or overlapping between tiles and dividers');
+                        expect(element, 'to have no gap or overlapping between tiles');
+                    });
+
+                    describe('and the viewport is scrolled to the bottom', function () {
+                        beforeEach(function () {
+                            scrollToBottom(scrollElement);
+                        });
+
+                        it('still has ' + numberOfItems + ' tiles', function () {
+                            expect(element, 'to have number of tiles', numberOfItems);
+                        });
+
+                        it('has no overlapping tiles', function () {
+                            expect(element, 'to have no gap or overlapping between tiles');
+                        });
+
+                        describe('and it has 3 dividers', function () {
+                            beforeEach(function () {
+                                model.dividers({ 20: "A", 40: 'B', 60: 'C' });
+                                clock.tick(110);
+                            });
+
+                            it('places all dividers sequential from the start of the list', function () {
+                                expect(element, 'to have number of dividers', 3);
+                            });
+
+                            it('has scroll height equals to the height of all items and dividers', function () {
+                                expect(scrollElement, 'to have scroll height', dividerHeight * 3 + numberOfItems * itemHeight + 2 * offsetElementHeight);
+                            });
+
+                            it('has content height equals to the height of all items and dividers', function () {
+                                expect(element, 'to have content height', dividerHeight * 3 + numberOfItems * itemHeight);
+                            });
+
+                            it('has no overlapping tiles', function () {
+                                expect(element, 'to have no gap or overlapping between tiles and dividers');
+                            });
+                        });
+
+                        describe('and the visible index is set to the first item', function () {
+                            beforeEach(function () {
+                                model.visibleIndex(0);
+                                clock.tick(110);
+                            });
+
+                            it('scrolls the first item into view', function () {
+                                expect(scrollElement, 'to have scroll top', 0 + offsetElementHeight);
+                            });
+                        });
+                    });
+
+                });
+
+                describe('when the data source is larger then the eviction treshold of 100 items', function () {
+                    var model;
+                    var numberOfItems = 100;
+                    beforeEach(function () {
+                        model = {
+                            items: ko.observableArray(itemFactory.create(numberOfItems)),
+                            visibleIndex: ko.observable(0).extend({ notify: 'always' }),
+                            dividers: ko.observable()
+                        };
+                        ko.applyBindings(model, element);
+                        clock.tick(110);
+                    });
+
+                    it('has scroll height equals to the height of all items', function () {
+                        expect(scrollElement, 'to have scroll height', numberOfItems * itemHeight + 2 * offsetElementHeight);
+                    });
+
+                    it('has content height equals to the height of all items', function () {
+                        expect(element, 'to have content height', numberOfItems * itemHeight);
+                    });
+
+                    it('has tiles item0 to item5', function () {
+                        expect(element, 'to only have tiles', tileRange(0, 5));
+                    });
+
+                    it('has no overlapping tiles', function () {
+                        expect(element, 'to have no gap or overlapping between tiles');
+                    });
+
+                    describe('and the viewport is scrolled to item 20', function () {
+                        beforeEach(function () {
+                            scrollTo(scrollElement, 20 * itemHeight + offsetElementHeight);
+                            clock.tick(110);
+                        });
+
+                        it('has tiles item17 to item25', function () {
+                            clock.tick(110);
+                            expect(element, 'to only have tiles', tileRange(17, 25));
+                        });
+
+                        it('has no overlapping tiles', function () {
+                            expect(element, 'to have no gap or overlapping between tiles');
+                        });
+                    });
+
+                    describe('and the viewport is scrolled to item 20 and back to item 10', function () {
+                        beforeEach(function () {
+                            scrollTo(scrollElement, 20 * itemHeight + offsetElementHeight);
+                            scrollTo(scrollElement, 10 * itemHeight + offsetElementHeight);
+                            clock.tick(110);
+                        });
+
+                        it('has tiles item7 to item15', function () {
+                            expect(element, 'to only have tiles', tileRange(7, 15));
+                        });
+
+                        it('has no overlapping tiles', function () {
+                            expect(element, 'to have no gap or overlapping between tiles');
+                        });
+
+                        describe('and it has 3 dividers', function () {
+                            beforeEach(function () {
+                                model.dividers({ 10: "A", 40: 'B', 60: 'C' });
+                                clock.tick(110);
+                            });
+
+                            it('places all dividers sequential from the start of the list', function () {
+                                expect(element, 'to have number of dividers', 3);
+                            });
+
+                            it('has scroll height equals to the height of all items and dividers', function () {
+                                expect(scrollElement, 'to have scroll height', dividerHeight * 3 + numberOfItems * itemHeight + 2 * offsetElementHeight);
+                            });
+
+                            it('has content height equals to the height of all items and dividers', function () {
+                                expect(element, 'to have content height', dividerHeight * 3 + numberOfItems * itemHeight);
+                            });
+
+                            it('has no overlapping tiles', function () {
+                                expect(element, 'to have no gap or overlapping between tiles');
+                            });
+                        });
+                    });
+
+                    describe('and the viewport is scrolled to the bottom', function () {
+                        beforeEach(function () {
+                            scrollToBottom(scrollElement);
+                            clock.tick(110);
+                        });
+
+                        it('has tiles item95 to item99', function () {
+                            expect(element, 'to only have tiles', tileRange(95, 99));
+                        });
+
+                        it('has no overlapping tiles', function () {
+                            expect(element, 'to have no gap or overlapping between tiles');
+                        });
+
+                        describe('and it has 3 dividers', function () {
+                            beforeEach(function () {
+                                model.dividers({ 10: "A", 40: 'B', 95: 'C' });
+                                clock.tick(110);
+                            });
+
+                            it('places all dividers sequential from the start of the list', function () {
+                                expect(element, 'to have number of dividers', 3);
+                            });
+
+                            it('has scroll height equals to the height of all items and dividers', function () {
+                                expect(scrollElement, 'to have scroll height', dividerHeight * 3 + numberOfItems * itemHeight + 2 * offsetElementHeight);
+                            });
+
+                            it('has content height equals to the height of all items and dividers', function () {
+                                expect(element, 'to have content height', dividerHeight * 3 + numberOfItems * itemHeight);
+                            });
+
+                            it('has no overlapping tiles', function () {
+                                expect(element, 'to have no gap or overlapping between tiles');
+                            });
+                        });
+                    });
+
+                    describe('and a new item is added to the bottom of the list that is outside of the render tiles', function () {
+                        beforeEach(function () {
+                            model.items.push(itemFactory());
+                            clock.tick(110);
+                            model.visibleIndex(model.items().length - 1);
+                            $(scrollElement).trigger('scroll');
+                            clock.tick(110);
+                        });
+
+                        it('has tiles item95 to item100', function () {
+                            expect(element, 'to only have tiles', tileRange(95, 100));
+                        });
+
+                        it('has scroll height equals to the height of all items', function () {
+                            expect(scrollElement, 'to have scroll height', (numberOfItems + 1) * itemHeight + 2 * offsetElementHeight);
+                        });
+
+                        it('has content height equals to the height of all items', function () {
+                            expect(element, 'to have content height', (numberOfItems + 1) * itemHeight);
+                        });
+
+                        it('has no overlapping tiles', function () {
+                            expect(element, 'to have no gap or overlapping between tiles');
+                        });
+                    });
+
+                    describe('and a new item is added to the middle of the list that is outside of the render tiles', function () {
+                        beforeEach(function () {
+                            model.items.splice(50, 0, itemFactory('newItem'));
+                            clock.tick(110);
+                            model.visibleIndex(50);
+                            $(scrollElement).trigger('scroll');
+                            clock.tick(110);
+                        });
+
+                        it('has tiles item45 to item52 and the new item', function () {
+                            expect(element, 'to only have tiles', tileRange(45, 52).concat('#newItem'));
+                        });
+
+                        it('has scroll height equals to the height of all items', function () {
+                            expect(scrollElement, 'to have scroll height', (numberOfItems + 1) * itemHeight + 2 * offsetElementHeight);
+                        });
+
+                        it('has content height equals to the height of all items', function () {
+                            expect(element, 'to have content height', (numberOfItems + 1) * itemHeight);
+                        });
+
+                        it('has no overlapping tiles', function () {
+                            expect(element, 'to have no gap or overlapping between tiles');
+                        });
+                    });
+
+                    describe('and a new item inside the viewport', function () {
+                        beforeEach(function () {
+                            scrollTo(scrollElement, 50 * itemHeight + offsetElementHeight);
+                            model.items.splice(51, 0, itemFactory('newItem'));
+                            clock.tick(110);
+                        });
+
+                        it('has tiles item47 to item54 and the new item', function () {
+                            expect(element, 'to only have tiles', tileRange(47, 54).concat('#newItem'));
+                        });
+
+                        it('has scroll height equals to the height of all items', function () {
+                            expect(scrollElement, 'to have scroll height', (numberOfItems + 1) * itemHeight + 2 * offsetElementHeight);
+                        });
+
+                        it('has content height equals to the height of all items', function () {
+                            expect(element, 'to have content height', (numberOfItems + 1) * itemHeight);
+                        });
+
+                        it('has no overlapping tiles', function () {
+                            expect(element, 'to have no gap or overlapping between tiles');
+                        });
+                    });
+
+                    describe('and items has just been sorted in the reverse direction', function () {
+                        beforeEach(function () {
+                            scrollTo(scrollElement, 50 * itemHeight + offsetElementHeight);
+                            model.items.sort(function (x, y) {
+                                return parseInt(y.slice(4), 10) - parseInt(x.slice(4), 10);
+                            });
+                            clock.tick(110);
+                        });
+
+                        it('has tiles item44 to item52 and the new item', function () {
+                            expect(element, 'to only have tiles', tileRange(44, 52));
+                        });
+
+                        it('has scroll height equals to the height of all items', function () {
+                            expect(scrollElement, 'to have scroll height', numberOfItems * itemHeight + 2 * offsetElementHeight);
+                        });
+
+                        it('has content height equals to the height of all items', function () {
+                            expect(element, 'to have content height', numberOfItems * itemHeight);
+                        });
+
+                        it('has no overlapping tiles', function () {
+                            expect(element, 'to have no gap or overlapping between tiles');
+                        });
+                    });
+
+                    describe('and the data is replaced', function () {
+                        beforeEach(function () {
+                            scrollTo(scrollElement, 50 * itemHeight + offsetElementHeight);
+                            clock.tick(110);
+                            model.items(itemFactory.create(100));
+                            clock.tick(110);
+                        });
+
+                        it('has tiles item147 to item155 and the new item', function () {
+                            expect(element, 'to only have tiles', tileRange(147, 155));
+                        });
+
+                        it('has scroll height equals to the height of all items', function () {
+                            expect(scrollElement, 'to have scroll height', numberOfItems * itemHeight + 2 * offsetElementHeight);
+                        });
+
+                        it('has content height equals to the height of all items', function () {
+                            expect(element, 'to have content height', numberOfItems * itemHeight);
+                        });
+
+                        it('has no overlapping tiles', function () {
+                            expect(element, 'to have no gap or overlapping between tiles');
+                        });
                     });
                 });
             });
+        }); // end with offset
 
-            describe('when the data source is smaller then the eviction treshold of 100 items', function () {
-                var model;
-                var numberOfItems = 99;
-                beforeEach(function () {
-                    model = {
-                        items: ko.observableArray(itemFactory.create(numberOfItems)),
-                        visibleIndex: ko.observable(0).extend({ notify: 'always' }),
-                        dividers: ko.observable()
-                    };
-                    ko.applyBindings(model, element);
-                    clock.tick(110);
+        describe('with offset elements larger than the viewport above and below list', function () {
+            var bigOffsetElementHeight = viewportHeight * 2;
+            beforeEach(function () {
+                element = createTestElementWithScrollableParent({
+                    viewportHeight: viewportHeight,
+                    itemHeight: itemHeight,
+                    offsetElementHeight: bigOffsetElementHeight
                 });
+                scrollElement = $(element).parents('.scrollable').get(0);
+            });
 
-                it('renders ' + numberOfItems + ' tiles', function () {
-                    expect(element, 'to have number of tiles', numberOfItems);
-                });
-
-                it('has scroll height equals to the height of all items', function () {
-                    expect(scrollElement, 'to have scroll height', numberOfItems * itemHeight + 2 * offsetElementHeight);
-                });
-
-                it('has content height equals to the height of all items', function () {
-                    expect(element, 'to have content height', numberOfItems * itemHeight);
-                });
-
-                it('has no overlapping tiles', function () {
-                    expect(element, 'to have no gap or overlapping between tiles');
-                });
-
-                describe('and the viewport is scrolled to the bottom', function () {
+            describe('with an observable array as data source', function () {
+                describe('when the data source is smaller then the eviction treshold of 100 items', function () {
+                    var model;
+                    var numberOfItems = 99;
                     beforeEach(function () {
-                        scrollElement.scrollTop = offsetElementHeight + element.scrollHeight;
+                        model = {
+                            items: ko.observableArray(itemFactory.create(numberOfItems)),
+                            visibleIndex: ko.observable(0).extend({ notify: 'always' }),
+                            dividers: ko.observable()
+                        };
+                        ko.applyBindings(model, element);
+                        clock.tick(110);
                     });
 
-                    it('still has ' + numberOfItems + ' tiles', function () {
+                    it('renders ' + numberOfItems + ' tiles', function () {
                         expect(element, 'to have number of tiles', numberOfItems);
+                    });
+
+                    it('has scroll height equals to the height of all items', function () {
+                        expect(scrollElement, 'to have scroll height', numberOfItems * itemHeight + 2 * bigOffsetElementHeight);
+                    });
+
+                    it('has content height equals to the height of all items', function () {
+                        expect(element, 'to have content height', numberOfItems * itemHeight);
                     });
 
                     it('has no overlapping tiles', function () {
@@ -560,7 +892,7 @@ describe('knockout.list with height ' + viewportHeight + 'px and items of height
                         });
 
                         it('has scroll height equals to the height of all items and dividers', function () {
-                            expect(scrollElement, 'to have scroll height', dividerHeight * 3 + numberOfItems * itemHeight + 2 * offsetElementHeight);
+                            expect(scrollElement, 'to have scroll height', dividerHeight * 3 + numberOfItems * itemHeight + 2 * bigOffsetElementHeight);
                         });
 
                         it('has content height equals to the height of all items and dividers', function () {
@@ -572,6 +904,34 @@ describe('knockout.list with height ' + viewportHeight + 'px and items of height
                         });
                     });
 
+                    describe('and the viewport is scrolled to the top', function () {
+                        beforeEach(function () {
+                            scrollToTop(scrollElement);
+                        });
+
+                        it('still has ' + numberOfItems + ' tiles', function () {
+                            expect(element, 'to have number of tiles', numberOfItems);
+                        });
+
+                        it('has no overlapping tiles', function () {
+                            expect(element, 'to have no gap or overlapping between tiles');
+                        });
+                    });
+
+                    describe('and the viewport is scrolled to the bottom', function () {
+                        beforeEach(function () {
+                            scrollToBottom(scrollElement);
+                        });
+
+                        it('still has ' + numberOfItems + ' tiles', function () {
+                            expect(element, 'to have number of tiles', numberOfItems);
+                        });
+
+                        it('has no overlapping tiles', function () {
+                            expect(element, 'to have no gap or overlapping between tiles');
+                        });
+                    });
+
                     describe('and the visible index is set to the first item', function () {
                         beforeEach(function () {
                             model.visibleIndex(0);
@@ -579,67 +939,45 @@ describe('knockout.list with height ' + viewportHeight + 'px and items of height
                         });
 
                         it('scrolls the first item into view', function () {
-                            expect(scrollElement, 'to have scroll top', 0 + offsetElementHeight);
+                            expect(scrollElement, 'to have scroll top', 0 + bigOffsetElementHeight);
+                        });
+                    });
+
+                    describe('and the visible index is set to the last item', function () {
+                        beforeEach(function () {
+                            model.visibleIndex(98);
+                            clock.tick(110);
+                        });
+
+                        it('scrolls the last item into view', function () {
+                            expect(scrollElement, 'to have scroll top', 0 + bigOffsetElementHeight - viewportHeight + numberOfItems * itemHeight);
                         });
                     });
                 });
 
-            });
-
-            describe('when the data source is larger then the eviction treshold of 100 items', function () {
-                var model;
-                var numberOfItems = 100;
-                beforeEach(function () {
-                    model = {
-                        items: ko.observableArray(itemFactory.create(numberOfItems)),
-                        visibleIndex: ko.observable(0).extend({ notify: 'always' }),
-                        dividers: ko.observable()
-                    };
-                    ko.applyBindings(model, element);
-                    clock.tick(110);
-                });
-
-                it('has scroll height equals to the height of all items', function () {
-                    expect(scrollElement, 'to have scroll height', numberOfItems * itemHeight + 2 * offsetElementHeight);
-                });
-
-                it('has content height equals to the height of all items', function () {
-                    expect(element, 'to have content height', numberOfItems * itemHeight);
-                });
-
-                it('has tiles item0 to item5', function () {
-                    expect(element, 'to only have tiles', tileRange(0, 5));
-                });
-
-                it('has no overlapping tiles', function () {
-                    expect(element, 'to have no gap or overlapping between tiles');
-                });
-
-                describe('and the viewport is scrolled to item 20', function () {
+                describe('when the data source is larger then the eviction treshold of 100 items', function () {
+                    var model;
+                    var numberOfItems = 100;
                     beforeEach(function () {
-                        scrollTo(scrollElement, 20 * itemHeight + offsetElementHeight);
+                        model = {
+                            items: ko.observableArray(itemFactory.create(numberOfItems)),
+                            visibleIndex: ko.observable(0).extend({ notify: 'always' }),
+                            dividers: ko.observable()
+                        };
+                        ko.applyBindings(model, element);
                         clock.tick(110);
                     });
 
-                    it('has tiles item17 to item25', function () {
-                        clock.tick(110);
-                        expect(element, 'to only have tiles', tileRange(17, 25));
+                    it('has scroll height equals to the height of all items', function () {
+                        expect(scrollElement, 'to have scroll height', numberOfItems * itemHeight + 2 * bigOffsetElementHeight);
                     });
 
-                    it('has no overlapping tiles', function () {
-                        expect(element, 'to have no gap or overlapping between tiles');
-                    });
-                });
-
-                describe('and the viewport is scrolled to item 20 and back to item 10', function () {
-                    beforeEach(function () {
-                        scrollTo(scrollElement, 20 * itemHeight + offsetElementHeight);
-                        scrollTo(scrollElement, 10 * itemHeight + offsetElementHeight);
-                        clock.tick(110);
+                    it('has content height equals to the height of all items', function () {
+                        expect(element, 'to have content height', numberOfItems * itemHeight);
                     });
 
-                    it('has tiles item7 to item15', function () {
-                        expect(element, 'to only have tiles', tileRange(7, 15));
+                    it('has tiles item0 to item5', function () {
+                        expect(element, 'to only have tiles', tileRange(0, 5));
                     });
 
                     it('has no overlapping tiles', function () {
@@ -657,7 +995,7 @@ describe('knockout.list with height ' + viewportHeight + 'px and items of height
                         });
 
                         it('has scroll height equals to the height of all items and dividers', function () {
-                            expect(scrollElement, 'to have scroll height', dividerHeight * 3 + numberOfItems * itemHeight + 2 * offsetElementHeight);
+                            expect(scrollElement, 'to have scroll height', dividerHeight * 3 + numberOfItems * itemHeight + 2 * bigOffsetElementHeight);
                         });
 
                         it('has content height equals to the height of all items and dividers', function () {
@@ -668,38 +1006,181 @@ describe('knockout.list with height ' + viewportHeight + 'px and items of height
                             expect(element, 'to have no gap or overlapping between tiles');
                         });
                     });
-                });
 
-                describe('and the viewport is scrolled to the bottom', function () {
-                    beforeEach(function () {
-                        scrollToBottom(scrollElement);
-                        clock.tick(110);
-                    });
-
-                    it('has tiles item95 to item99', function () {
-                        expect(element, 'to only have tiles', tileRange(95, 99));
-                    });
-
-                    it('has no overlapping tiles', function () {
-                        expect(element, 'to have no gap or overlapping between tiles');
-                    });
-
-                    describe('and it has 3 dividers', function () {
+                    describe('and the viewport is scrolled to item 20', function () {
                         beforeEach(function () {
-                            model.dividers({ 10: "A", 40: 'B', 95: 'C' });
+                            scrollTo(scrollElement, 20 * itemHeight + bigOffsetElementHeight);
                             clock.tick(110);
                         });
 
-                        it('places all dividers sequential from the start of the list', function () {
-                            expect(element, 'to have number of dividers', 3);
+                        it('has tiles item17 to item25', function () {
+                            clock.tick(110);
+                            expect(element, 'to only have tiles', tileRange(17, 25));
                         });
 
-                        it('has scroll height equals to the height of all items and dividers', function () {
-                            expect(scrollElement, 'to have scroll height', dividerHeight * 3 + numberOfItems * itemHeight + 2 * offsetElementHeight);
+                        it('has no overlapping tiles', function () {
+                            expect(element, 'to have no gap or overlapping between tiles');
+                        });
+                    });
+
+                    describe('and the viewport is scrolled to item 20 and back to item 10', function () {
+                        beforeEach(function () {
+                            scrollTo(scrollElement, 20 * itemHeight + bigOffsetElementHeight);
+                            scrollTo(scrollElement, 10 * itemHeight + bigOffsetElementHeight);
+                            clock.tick(110);
                         });
 
-                        it('has content height equals to the height of all items and dividers', function () {
-                            expect(element, 'to have content height', dividerHeight * 3 + numberOfItems * itemHeight);
+                        it('has tiles item7 to item15', function () {
+                            expect(element, 'to only have tiles', tileRange(7, 15));
+                        });
+
+                        it('has no overlapping tiles', function () {
+                            expect(element, 'to have no gap or overlapping between tiles');
+                        });
+                    });
+
+                    describe('and the viewport is scrolled to the top', function () {
+                        beforeEach(function () {
+                            scrollToTop(scrollElement);
+                            clock.tick(110);
+                        });
+
+                        it('renders 0 tiles', function () {
+                            expect(element, 'to have number of tiles', 0);
+                        });
+                    });
+
+                    describe('and the viewport is scrolled to the bottom', function () {
+                        beforeEach(function () {
+                            scrollToBottom(scrollElement);
+                            clock.tick(110);
+                        });
+
+                        it('renders 0 tiles', function () {
+                            expect(element, 'to have number of tiles', 0);
+                        });
+                    });
+
+                    describe('and a new item is added to the bottom of the list that is outside of the render tiles', function () {
+                        beforeEach(function () {
+                            model.items.push(itemFactory());
+                            clock.tick(110);
+                            model.visibleIndex(model.items().length - 1);
+                            $(scrollElement).trigger('scroll');
+                            clock.tick(110);
+                        });
+
+                        it('has tiles item95 to item100', function () {
+                            expect(element, 'to only have tiles', tileRange(95, 100));
+                        });
+
+                        it('has scroll height equals to the height of all items', function () {
+                            expect(scrollElement, 'to have scroll height', (numberOfItems + 1) * itemHeight + 2 * bigOffsetElementHeight);
+                        });
+
+                        it('has content height equals to the height of all items', function () {
+                            expect(element, 'to have content height', (numberOfItems + 1) * itemHeight);
+                        });
+
+                        it('has no overlapping tiles', function () {
+                            expect(element, 'to have no gap or overlapping between tiles');
+                        });
+                    });
+
+                    describe('and a new item is added to the middle of the list that is outside of the render tiles', function () {
+                        beforeEach(function () {
+                            model.items.splice(50, 0, itemFactory('newItem'));
+                            clock.tick(110);
+                            model.visibleIndex(50);
+                            $(scrollElement).trigger('scroll');
+                            clock.tick(110);
+                        });
+
+                        it('has tiles item45 to item52 and the new item', function () {
+                            expect(element, 'to only have tiles', tileRange(45, 52).concat('#newItem'));
+                        });
+
+                        it('has scroll height equals to the height of all items', function () {
+                            expect(scrollElement, 'to have scroll height', (numberOfItems + 1) * itemHeight + 2 * bigOffsetElementHeight);
+                        });
+
+                        it('has content height equals to the height of all items', function () {
+                            expect(element, 'to have content height', (numberOfItems + 1) * itemHeight);
+                        });
+
+                        it('has no overlapping tiles', function () {
+                            expect(element, 'to have no gap or overlapping between tiles');
+                        });
+                    });
+
+                    describe('and a new item inside the viewport', function () {
+                        beforeEach(function () {
+                            scrollTo(scrollElement, 50 * itemHeight + bigOffsetElementHeight);
+                            model.items.splice(51, 0, itemFactory('newItem'));
+                            clock.tick(110);
+                        });
+
+                        it('has tiles item47 to item54 and the new item', function () {
+                            expect(element, 'to only have tiles', tileRange(47, 54).concat('#newItem'));
+                        });
+
+                        it('has scroll height equals to the height of all items', function () {
+                            expect(scrollElement, 'to have scroll height', (numberOfItems + 1) * itemHeight + 2 * bigOffsetElementHeight);
+                        });
+
+                        it('has content height equals to the height of all items', function () {
+                            expect(element, 'to have content height', (numberOfItems + 1) * itemHeight);
+                        });
+
+                        it('has no overlapping tiles', function () {
+                            expect(element, 'to have no gap or overlapping between tiles');
+                        });
+                    });
+
+                    describe('and items has just been sorted in the reverse direction', function () {
+                        beforeEach(function () {
+                            scrollTo(scrollElement, 50 * itemHeight + bigOffsetElementHeight);
+                            model.items.sort(function (x, y) {
+                                return parseInt(y.slice(4), 10) - parseInt(x.slice(4), 10);
+                            });
+                            clock.tick(110);
+                        });
+
+                        it('has tiles item44 to item52 and the new item', function () {
+                            expect(element, 'to only have tiles', tileRange(44, 52));
+                        });
+
+                        it('has scroll height equals to the height of all items', function () {
+                            expect(scrollElement, 'to have scroll height', numberOfItems * itemHeight + 2 * bigOffsetElementHeight);
+                        });
+
+                        it('has content height equals to the height of all items', function () {
+                            expect(element, 'to have content height', numberOfItems * itemHeight);
+                        });
+
+                        it('has no overlapping tiles', function () {
+                            expect(element, 'to have no gap or overlapping between tiles');
+                        });
+                    });
+
+                    describe('and the data is replaced', function () {
+                        beforeEach(function () {
+                            scrollTo(scrollElement, 50 * itemHeight + bigOffsetElementHeight);
+                            clock.tick(110);
+                            model.items(itemFactory.create(100));
+                            clock.tick(110);
+                        });
+
+                        it('has tiles item147 to item155 and the new item', function () {
+                            expect(element, 'to only have tiles', tileRange(147, 155));
+                        });
+
+                        it('has scroll height equals to the height of all items', function () {
+                            expect(scrollElement, 'to have scroll height', numberOfItems * itemHeight + 2 * bigOffsetElementHeight);
+                        });
+
+                        it('has content height equals to the height of all items', function () {
+                            expect(element, 'to have content height', numberOfItems * itemHeight);
                         });
 
                         it('has no overlapping tiles', function () {
@@ -708,132 +1189,6 @@ describe('knockout.list with height ' + viewportHeight + 'px and items of height
                     });
                 });
 
-                describe('and a new item is added to the bottom of the list that is outside of the render tiles', function () {
-                    beforeEach(function () {
-                        model.items.push(itemFactory());
-                        clock.tick(110);
-                        model.visibleIndex(model.items().length - 1);
-                        $(scrollElement).trigger('scroll');
-                        clock.tick(110);
-                    });
-
-                    it('has tiles item95 to item100', function () {
-                        expect(element, 'to only have tiles', tileRange(95, 100));
-                    });
-
-                    it('has scroll height equals to the height of all items', function () {
-                        expect(scrollElement, 'to have scroll height', (numberOfItems + 1) * itemHeight + 2 * offsetElementHeight);
-                    });
-
-                    it('has content height equals to the height of all items', function () {
-                        expect(element, 'to have content height', (numberOfItems + 1) * itemHeight);
-                    });
-
-                    it('has no overlapping tiles', function () {
-                        expect(element, 'to have no gap or overlapping between tiles');
-                    });
-                });
-
-                describe('and a new item is added to the middle of the list that is outside of the render tiles', function () {
-                    beforeEach(function () {
-                        model.items.splice(50, 0, itemFactory('newItem'));
-                        clock.tick(110);
-                        model.visibleIndex(50);
-                        $(scrollElement).trigger('scroll');
-                        clock.tick(110);
-                    });
-
-                    it('has tiles item45 to item52 and the new item', function () {
-                        expect(element, 'to only have tiles', tileRange(45, 52).concat('#newItem'));
-                    });
-
-                    it('has scroll height equals to the height of all items', function () {
-                        expect(scrollElement, 'to have scroll height', (numberOfItems + 1) * itemHeight + 2 * offsetElementHeight);
-                    });
-
-                    it('has content height equals to the height of all items', function () {
-                        expect(element, 'to have content height', (numberOfItems + 1) * itemHeight);
-                    });
-
-                    it('has no overlapping tiles', function () {
-                        expect(element, 'to have no gap or overlapping between tiles');
-                    });
-                });
-
-                describe('and a new item inside the viewport', function () {
-                    beforeEach(function () {
-                        scrollTo(scrollElement, 50 * itemHeight + offsetElementHeight);
-                        model.items.splice(51, 0, itemFactory('newItem'));
-                        clock.tick(110);
-                    });
-
-                    it('has tiles item47 to item54 and the new item', function () {
-                        expect(element, 'to only have tiles', tileRange(47, 54).concat('#newItem'));
-                    });
-
-                    it('has scroll height equals to the height of all items', function () {
-                        expect(scrollElement, 'to have scroll height', (numberOfItems + 1) * itemHeight + 2 * offsetElementHeight);
-                    });
-
-                    it('has content height equals to the height of all items', function () {
-                        expect(element, 'to have content height', (numberOfItems + 1) * itemHeight);
-                    });
-
-                    it('has no overlapping tiles', function () {
-                        expect(element, 'to have no gap or overlapping between tiles');
-                    });
-                });
-
-                describe('and items has just been sorted in the reverse direction', function () {
-                    beforeEach(function () {
-                        scrollTo(scrollElement, 50 * itemHeight + offsetElementHeight);
-                        model.items.sort(function (x, y) {
-                            return parseInt(y.slice(4), 10) - parseInt(x.slice(4), 10);
-                        });
-                        clock.tick(110);
-                    });
-
-                    it('has tiles item44 to item52 and the new item', function () {
-                        expect(element, 'to only have tiles', tileRange(44, 52));
-                    });
-
-                    it('has scroll height equals to the height of all items', function () {
-                        expect(scrollElement, 'to have scroll height', numberOfItems * itemHeight + 2 * offsetElementHeight);
-                    });
-
-                    it('has content height equals to the height of all items', function () {
-                        expect(element, 'to have content height', numberOfItems * itemHeight);
-                    });
-
-                    it('has no overlapping tiles', function () {
-                        expect(element, 'to have no gap or overlapping between tiles');
-                    });
-                });
-
-                describe('and the data is replaced', function () {
-                    beforeEach(function () {
-                        scrollTo(scrollElement, 50 * itemHeight + offsetElementHeight);
-                        clock.tick(110);
-                        model.items(itemFactory.create(100));
-                        clock.tick(110);
-                    });
-
-                    it('has tiles item147 to item155 and the new item', function () {
-                        expect(element, 'to only have tiles', tileRange(147, 155));
-                    });
-
-                    it('has scroll height equals to the height of all items', function () {
-                        expect(scrollElement, 'to have scroll height', numberOfItems * itemHeight + 2 * offsetElementHeight);
-                    });
-
-                    it('has content height equals to the height of all items', function () {
-                        expect(element, 'to have content height', numberOfItems * itemHeight);
-                    });
-
-                    it('has no overlapping tiles', function () {
-                        expect(element, 'to have no gap or overlapping between tiles');
-                    });
-                });
             });
         });
     }); // end 'scrolling through parent of element it is bound to'

--- a/test/spec.helper.js
+++ b/test/spec.helper.js
@@ -34,16 +34,20 @@ function createTestElementWithScrollableParent(options) {
     scrollableParent.height(options.viewportHeight);
     scrollableParent.width(options.viewportWidth);
 
-    var offsetElement = $('<div></div>');
-    offsetElement.height(options.offsetElementHeight);
-    offsetElement.width(options.offsetElementWidth);
+    var offsetTopElement = $('<div></div>');
+    offsetTopElement.height(options.offsetElementHeight);
+    offsetTopElement.width(options.offsetElementWidth);
+    var offsetBottomElement = $('<div></div>');
+    offsetBottomElement.height(options.offsetElementHeight);
+    offsetBottomElement.width(options.offsetElementWidth);
     var list = $('<div data-bind="list: { data: items, visibleIndex: $data.visibleIndex, dividers: $data.dividers, scrollable:  \'.scrollable\' }"></div>');
     var item = $('<div data-bind="text: $data, attr: { id: $data }"></div>');
     item.height(options.itemHeight);
     list.append(item);
 
-    scrollableParent.append(offsetElement);
+    scrollableParent.append(offsetTopElement);
     scrollableParent.append(list);
+    scrollableParent.append(offsetBottomElement);
     testContainer.append(scrollableParent);
 
     return list.get(0);

--- a/test/spec.helper.js
+++ b/test/spec.helper.js
@@ -92,6 +92,10 @@ function scrollTo(element, top) {
     $(element).trigger('scroll');
 }
 
+function scrollToTop(element) {
+    scrollTo(element, 0);
+}
+
 function scrollToBottom(element) {
     scrollTo(element, element.scrollHeight);
 }


### PR DESCRIPTION
Another day, another pull request.

This one prevents knockout.list from rendering tiles if the entire list is outside the viewport (and not within one viewport height's distance).

I'm considering adding a few more tests before this PR is ready for merging - currently only the test at line 680 ensures correct behaviour but it's too implicit to my taste - but comments about the direction are most welcome already
